### PR TITLE
Remove quote tile and decorative title periods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,25 +68,27 @@ Collection-specific extensions:
 | Layout | Purpose |
 |--------|---------|
 | `BaseLayout.astro` | Foundation wrapper with meta, styles, view transitions |
-| `SectionLayout.astro` | Content pages with NavPill and animated P4G header (currently unused by routes; canonical section header) |
-| `SplitViewLayout.astro` | Three-panel list/detail/emblem interface with client-side navigation and emblem card sidebar |
+| `SectionLayout.astro` | Content pages with NavPill and animated P4G header (still unused by routes; the unified section header now lives in `SplitViewLayout`) |
+| `SplitViewLayout.astro` | Three-panel list/detail/emblem interface with client-side navigation and emblem card sidebar. Optional `kicker` prop; renders the unified P4G section header (`p4g-tab` + `p4g-heading` + `p4g-underline`) — the same header pattern is replicated on the Now, Now-archive, and Novel pages |
 
 ## Component Inventory
 
 ### Structural
 - `BentoGrid.astro` / `BentoTile.astro` — Homepage grid system with visual hierarchy
-- `NavPill.astro` — Floating bottom navigation
+- `NavPill.astro` — Fixed bottom-left P4G angled nav bar (`.nav-bar`, corner-cut clip-path, hard gold shadow via `drop-shadow` wrapper). Links Home/Showcase/Notes/Shelf/Now with solid-gold active-page highlight (`.nav-bar__item--active` + `aria-current="page"`); optional `backLink`/`backLabel` props append a back link. Hidden on the homepage. (No longer the centered floating Home pill.)
 
 ### Bento Tile Hierarchy
 The homepage uses a visual hierarchy pattern:
 - **Core tiles** (`.bento-tile--core`): Main entry points (Showcase, Notes, Shelf) with elevated gold glow and larger typography
 - **Signal tiles**: Current activity indicators (Now, Latest) - smaller, secondary visual weight
-- **Stream tile**: Dark 1×2 tile linking to `/stream`; shows live stat donut chart with leading stat emblem and session count. Pulsing red border when live.
+- **Stream tile**: Dark 1×2 tile linking to `/stream`; shows live stat donut chart with leading stat emblem and session count. Pulsing red border (`--color-live`) when live.
 - **Logo tiles** (`.logo-tile`): External service links (MyAnimeList, Spotify) with 48x48px logos and hover effects
 - **YouTube tile**: Full-bleed channel avatar; switches to Twitch live preview when streaming
 
 Tile variants: `interactive` (default), `highlight` (gold bg), `dark`, `static`
 Sizes: `dominant` (2x2), `medium-wide` (2x1), `medium-tall` (1x2), `small` (1x1)
+
+**Hover signature**: the corner-cut triangle (`.bento-tile__corner` — gold triangle slides into the top-right on hover/focus) is the single hover signature for every interactive bento tile. Gold-background (`highlight`) tiles use a black triangle for contrast; `static` tiles hide it. Shelf cards have a matching `.shelf-card__corner`. BentoTile has no `accent` prop — the old `.bento-tile--accent` dot, corner-bracket `::after` decorations, and `.bento-tile--cyan` variant were all removed.
 Span classes: `.bento-tile--span-4x2`, `.bento-tile--span-3x2`, `.bento-tile--span-2x2`, `.bento-tile--span-2x1`, `.bento-tile--span-1x2`
 
 **Current Homepage Grid Pattern:**
@@ -125,6 +127,14 @@ Note: Title grid placement is controlled by scoped CSS in `index.astro` (`.title
 --color-gold: #ffe52c;           /* Primary accent (P4G yellow) */
 --color-bg-base: #111111;        /* Main background */
 --color-text: #f5f5f5;           /* Primary text */
+--color-live: #ff4040;           /* Live/stream red (badges, borders) */
+--color-live-rgb: 255, 64, 64;   /* For rgba() alpha variants */
+
+/* Radii — deliberately angular (P4G cuts corners, doesn't round them) */
+--radius-xs: 2px;
+--radius-sm: 3px;
+--radius-md: 4px;
+--radius-lg: 6px;
 
 /* Shadows (gold glow effect) */
 --shadow-hard: 4px 4px 0 rgba(255, 229, 44, 0.3);
@@ -226,7 +236,7 @@ The `splitView/` directory is modular: `contentLoader`, `emblemAnimation`, `even
 
 ## Important Implementation Details
 
-1. **SplitViewLayout JavaScript**: Three-panel layout (list/detail/emblem) with client-side fetch for detail content, History API for navigation, search/tag filtering (Cmd/Ctrl+K to focus search), emblem card flipping on content selection, falls back gracefully without JS
+1. **SplitViewLayout JavaScript**: Three-panel layout (list/detail/emblem) with client-side fetch for detail content, History API for navigation, search/tag filtering (Cmd/Ctrl+K to focus search), emblem card flipping on content selection, falls back gracefully without JS. On load with no slug in the URL, auto-opens the newest visible entry — desktop layout only (detected via the applied grid columns, not viewport width) and without pushing history or moving focus (`src/utils/splitView/index.ts`; `loadContent` accepts `{ pushHistory, focusHeading }` options)
 
 2. **View Transitions**: Uses Astro's ClientRouter with custom P4G-style slide animations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ Span classes: `.bento-tile--span-4x2`, `.bento-tile--span-3x2`, `.bento-tile--sp
 **Current Homepage Grid Pattern:**
 - Row 1: Title (4×1) + YouTube (1×1) + Now (1×1)
 - Rows 2-3: Showcase (3×2, core) + Notes (2×2, core) + Stream (1×2)
-- Rows 4-5: Shelf (2×2, core) + Latest (2×1, row 4) + Novel (1×2) + MAL (1×1, row 4) + Spotify (1×1, row 5) + 2× filler static tiles (1×1, row 5)
+- Rows 4-5: Shelf (2×2, core) + Latest (2×1, row 4) + Novel (1×2) + MAL (1×1, row 4) + Spotify (1×1, row 5) + back-to-top tile (1×1, row 5)
 
 Note: Title grid placement is controlled by scoped CSS in `index.astro` (`.title-tile { grid-column: span 4 }`), not a span class.
 

--- a/src/layouts/SectionLayout.astro
+++ b/src/layouts/SectionLayout.astro
@@ -17,7 +17,7 @@ const { title, description, subtitle, kicker } = Astro.props;
   <div class="container">
     <header class="section-header">
       {kicker && <span class="p4g-tab p3r-animate">{kicker}</span>}
-      <h1 class="section-header__title p3r-animate-left"><span class="p4g-heading">{title}<span class="section-header__period">.</span></span></h1>
+      <h1 class="section-header__title p3r-animate-left"><span class="p4g-heading">{title}</span></h1>
       <span class="p4g-underline" aria-hidden="true"></span>
       {subtitle && <p class="section-header__subtitle p3r-animate" style="--stagger-delay: 80ms;">{subtitle}</p>}
     </header>
@@ -42,11 +42,6 @@ const { title, description, subtitle, kicker } = Astro.props;
     text-shadow:
       0 0 30px rgba(255, 229, 44, 0.4),
       0 0 60px rgba(255, 229, 44, 0.2);
-  }
-
-  .section-header__period {
-    color: var(--color-text);
-    text-shadow: none;
   }
 
   .section-header__subtitle {

--- a/src/layouts/SplitViewLayout.astro
+++ b/src/layouts/SplitViewLayout.astro
@@ -38,7 +38,7 @@ const kickerText = kicker ?? SECTION_KICKERS[section] ?? section;
       <header class="split-view__header">
         <span class="p4g-tab">{kickerText}</span>
         <div class="split-view__header-top">
-          <h1 class="split-view__title"><span class="p4g-heading">{title}<span class="split-view__period">.</span></span></h1>
+          <h1 class="split-view__title"><span class="p4g-heading">{title}</span></h1>
           <span class="split-view__count" id="split-count" aria-live="polite"></span>
         </div>
         <span class="p4g-underline" aria-hidden="true"></span>
@@ -178,10 +178,6 @@ const kickerText = kicker ?? SECTION_KICKERS[section] ?? section;
     line-height: 1.1;
     word-wrap: break-word;
     overflow-wrap: break-word;
-  }
-
-  .split-view__period {
-    color: var(--color-gold);
   }
 
   .split-view__header .p4g-underline {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -144,7 +144,7 @@ const latestEntries = sameDateEntries.map(entry => ({
       <div class="title-tile p3r-animate-left">
         <div class="title-tile__inner">
           <div class="title-tile__rule title-tile__rule--top" aria-hidden="true"></div>
-          <span class="title-tile__name"><span class="title-tile__name-inner">Ninjaruss<span class="title-tile__period">.</span></span></span>
+          <span class="title-tile__name"><span class="title-tile__name-inner">Ninjaruss</span></span>
           <div class="title-tile__rule title-tile__rule--bottom" aria-hidden="true"></div>
         </div>
         <p class="title-tile__description">Live without regret.</p>
@@ -479,12 +479,7 @@ const latestEntries = sameDateEntries.map(entry => ({
         <p class="logo-tile__description">The bangers I listen to every day.</p>
       </a>
 
-      <!-- Row 5 — quote card + back-to-top fill cols left empty by Latest (2×1) and MAL (1×1) -->
-      <div class="bento-tile bento-tile--dark quote-tile" id="quote-tile">
-        <span class="quote-tile__mark" aria-hidden="true">&ldquo;</span>
-        <p class="quote-tile__text" id="quote-text">Live without regret.</p>
-      </div>
-
+      <!-- Row 5 — back-to-top fills a col left empty by Latest (2×1) and MAL (1×1) -->
       <button type="button" class="bento-tile bento-tile--dark totop-tile" id="totop-tile" aria-label="Back to top">
         <span class="totop-tile__arrow" aria-hidden="true">↑</span>
         <span class="totop-tile__label">Top</span>
@@ -725,11 +720,6 @@ const latestEntries = sameDateEntries.map(entry => ({
   .title-tile__name-inner {
     display: inline-block;
     transform: skewX(var(--skew-display));
-  }
-
-  .title-tile__period {
-    color: var(--color-text);
-    text-shadow: none;
   }
 
   /* Tagline: always subtly visible, sharpens on hover */
@@ -1495,33 +1485,6 @@ const latestEntries = sameDateEntries.map(entry => ({
     opacity: 1;
   }
 
-  /* Quote tile — replaces a dead spacer with a rotating P4G line */
-  .quote-tile {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    gap: var(--space-xs);
-    overflow: hidden;
-  }
-
-  .quote-tile__mark {
-    font-family: var(--font-display);
-    font-size: 2.4rem;
-    line-height: 0.6;
-    color: var(--color-gold-dim);
-    opacity: 0.45;
-  }
-
-  .quote-tile__text {
-    margin: 0;
-    font-family: var(--font-mono);
-    font-size: var(--text-xs);
-    font-style: italic;
-    line-height: 1.45;
-    color: var(--color-text-muted);
-    transition: opacity 300ms ease;
-  }
-
   /* Back-to-top tile — self-contained control filling the last cell */
   .totop-tile {
     display: flex;
@@ -1805,45 +1768,6 @@ const latestEntries = sameDateEntries.map(entry => ({
     });
   }
 
-  // Rotating quote tile
-  const QUOTES = [
-    'Live without regret.',
-    'The bonds you forge are your true strength.',
-    'Pierce the heavens with your own hands.',
-    'No mask. Just the truth.',
-    'Into the dark without a torch.',
-    'So the world will not forget.',
-  ];
-  let quoteInterval: ReturnType<typeof setInterval> | undefined;
-
-  function initializeQuoteTile() {
-    stopQuoteRotation();
-    const el = document.getElementById('quote-text');
-    if (!el) return;
-    let i = QUOTES.indexOf(el.textContent?.trim() ?? '');
-    if (i < 0) i = 0;
-    const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    quoteInterval = setInterval(() => {
-      i = (i + 1) % QUOTES.length;
-      if (reduce) {
-        el.textContent = QUOTES[i];
-        return;
-      }
-      el.style.opacity = '0';
-      setTimeout(() => {
-        el.textContent = QUOTES[i];
-        el.style.opacity = '';
-      }, 300);
-    }, 6000);
-  }
-
-  function stopQuoteRotation() {
-    if (quoteInterval !== undefined) {
-      clearInterval(quoteInterval);
-      quoteInterval = undefined;
-    }
-  }
-
   function initializeToTop() {
     const btn = document.getElementById('totop-tile');
     if (!btn) return;
@@ -1858,7 +1782,6 @@ const latestEntries = sameDateEntries.map(entry => ({
   initializeNovelTile();
   initializeEmblemLinks();
   initializeTilt();
-  initializeQuoteTile();
   initializeToTop();
   startLivePolling();
 
@@ -1868,7 +1791,6 @@ const latestEntries = sameDateEntries.map(entry => ({
     initializeNovelTile();
     initializeEmblemLinks();
     initializeTilt();
-    initializeQuoteTile();
     initializeToTop();
     startLivePolling();
   });
@@ -1876,6 +1798,5 @@ const latestEntries = sameDateEntries.map(entry => ({
   // Clean up intervals before navigating away
   document.addEventListener('astro:before-preparation', () => {
     stopLivePolling();
-    stopQuoteRotation();
   });
 </script>

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -26,7 +26,7 @@ const lastUpdated = latestPost.data.publishedAt.toLocaleDateString('en-US', {
       <header class="now__header">
         <span class="p4g-tab">snapshot</span>
         <div class="now__header-top">
-          <h1 class="now__title"><span class="p4g-heading">Now<span class="now__period">.</span></span></h1>
+          <h1 class="now__title"><span class="p4g-heading">Now</span></h1>
           <p class="now__updated" title="Date shown in UTC">
             <span class="now__updated-icon" aria-hidden="true">◈</span>
             {lastUpdated}
@@ -72,11 +72,6 @@ const lastUpdated = latestPost.data.publishedAt.toLocaleDateString('en-US', {
 
   .now__header :global(.p4g-underline) {
     margin-bottom: var(--space-md);
-  }
-
-  .now__period {
-    color: var(--color-text);
-    text-shadow: none;
   }
 
   .now__header-top {

--- a/src/pages/now/archive.astro
+++ b/src/pages/now/archive.astro
@@ -25,7 +25,7 @@ const latestSlug = sortedPosts[0]?.slug;
     <article class="now-archive">
       <header class="now-archive__header">
         <span class="p4g-tab">snapshot</span>
-        <h1 class="now-archive__title"><span class="p4g-heading">Archive<span class="now-archive__period">.</span></span></h1>
+        <h1 class="now-archive__title"><span class="p4g-heading">Archive</span></h1>
         <span class="p4g-underline" aria-hidden="true"></span>
         <p class="now-archive__description">Past snapshots of what I was focused on.</p>
         <a href="/now" class="now-archive__back">
@@ -84,11 +84,6 @@ const latestSlug = sortedPosts[0]?.slug;
     text-shadow:
       0 0 30px rgba(255, 229, 44, 0.4),
       0 0 60px rgba(255, 229, 44, 0.2);
-  }
-
-  .now-archive__period {
-    color: var(--color-text);
-    text-shadow: none;
   }
 
   .now-archive__description {

--- a/src/pages/shelf/index.astro
+++ b/src/pages/shelf/index.astro
@@ -74,7 +74,7 @@ const characterData = (characterGroup?.entries ?? []).map(e => ({
     <header class="shelf-header">
       <div class="shelf-header__main">
         <span class="p4g-tab">catalog</span>
-        <h1 class="shelf-header__title"><span class="p4g-heading">Shelf<span class="shelf-header__period">.</span></span></h1>
+        <h1 class="shelf-header__title"><span class="p4g-heading">Shelf</span></h1>
         <span class="p4g-underline" aria-hidden="true"></span>
       </div>
       <p class="shelf-header__count">{totalCount} entries</p>
@@ -228,9 +228,6 @@ const characterData = (characterGroup?.entries ?? []).map(e => ({
     flex-direction: column;
     align-items: flex-start;
     gap: var(--space-xs);
-  }
-  .shelf-header__period {
-    color: var(--color-gold);
   }
   .shelf-header__title {
     font-size: clamp(2rem, 5vw, 3.5rem);


### PR DESCRIPTION
## What changed

- **Removed the homepage quote tile** (`#quote-tile`) and its CSS/JS from `src/pages/index.astro`; the back-to-top tile now fills the remaining row-5 column on its own.
- **Removed the decorative trailing period** from section/title headings in `SectionLayout.astro`, `SplitViewLayout.astro`, the homepage title tile, and the Now, Now-archive, and Shelf page headers (along with their now-unused `__period` styles).
- **Updated CLAUDE.md** to document the P4G menu redesign: the new NavPill angled nav bar, corner-cut hover signature for bento tiles, `--color-live` and radii tokens, the unified section header living in `SplitViewLayout`, and the SplitView auto-open behavior.

## Why

Continues the P4G menu redesign cleanup — the quote tile and trailing periods were leftover decoration that no longer fit the tightened homepage grid and heading treatment, and CLAUDE.md needed to reflect the redesigned components so future sessions work from accurate docs.

## Notes for reviewers

- Net −91 lines; no behavior changes outside the removed tile.
- The homepage grid comment for row 5 was updated to match the new layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)